### PR TITLE
fix hang in subprocess.Popen / subprocess.wait()

### DIFF
--- a/foedus-core/tools/cpplint-wrapper.py
+++ b/foedus-core/tools/cpplint-wrapper.py
@@ -13,6 +13,7 @@ import string
 import subprocess
 import sys
 import time
+import tempfile
 import unicodedata
 
 
@@ -177,14 +178,18 @@ def exec_cpplint(files, cpplint_arguments):
     sys.stdout.write('Launching cpplint for ' + str(len(index_now)) + ' files.\n')
     # sys.stdout.write('arguments: ' + ' '.join(args) + '\n')
     # sys.stdout.write('Launching cpplint (' + cpplint_file + ') for ' + str(len(files))
-    #                  + ' files. arguments: ' + ' '.join(args) + '\n')
-    proc = subprocess.Popen(args, bufsize=65536, stderr=subprocess.PIPE, close_fds=True)
+    #                 + ' files. arguments: ' + ' '.join(args) + '\n')
+
+    tmpfile = tempfile.TemporaryFile()
+    proc = subprocess.Popen(args, bufsize=65536, stderr=tmpfile, close_fds=True)
     proc.wait()
+    # go to first line of tmpfile
+    tmpfile.seek(0)
     has_error = False
     clean_index = {}
     clean_index.update(index_last)
     clean_index.update(index_now)
-    for line in proc.stderr:
+    for line in tmpfile:
         # This is annoying. Why cpplint writes this to _stderr_??
         if not line.startswith("Done processing "):
             has_error = True


### PR DESCRIPTION
I experienced hangs when running the wrapper on projects with huge stylecheck errors.
The python doc (https://docs.python.org/2/library/subprocess.html#subprocess.Popen) has the following snippet concerning calling wait() on the subprocess object:

> Warning
This will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use communicate() to avoid that. 

My patch fixes this deadlock by using a temporary file object for storage/data passing